### PR TITLE
cpu_ibex: Fix wishbone address semantics

### DIFF
--- a/samples/cpu_ibex/sim_ibex.cpp
+++ b/samples/cpu_ibex/sim_ibex.cpp
@@ -7,9 +7,9 @@ void IbexBusInterface::connect(WishboneInitiator<uint32_t, uint32_t> &wishbone)
     wishbone.wb_ack = &rvalid_i();
     wishbone.wb_rd_dat = &rdata_i();
     wishbone.wb_stb = &req_o();
-    wishbone.wb_addr = &addr_o();
     wishbone.wb_wr_dat = &wdata_o();
     wishbone.wb_we = &we_o();
+    wishbone.wb_addr = &wb_addr;
     wishbone.wb_cyc = &wb_cyc;
     wishbone.wb_sel = &wb_sel;
     wishbone.wb_rst = &wb_rst;
@@ -20,6 +20,7 @@ void IbexBusInterface::convert(uint8_t clk)
 {
     gnt_i() = req_o() & ~wb_stall;
     wb_sel = be_o();
+    wb_addr = addr_o() / sizeof(uint32_t);
 
     if (wb_rst)
         wb_cyc = low;

--- a/samples/cpu_ibex/sim_ibex.h
+++ b/samples/cpu_ibex/sim_ibex.h
@@ -30,6 +30,7 @@ struct IbexBusInterface
     void connect(WishboneInitiator<uint32_t, uint32_t> &wishbone);
     void convert(uint8_t clk);
 
+    uint32_t wb_addr;
     uint8_t wb_cyc = 0, wb_sel, wb_rst = high, wb_stall = high;
 };
 


### PR DESCRIPTION
While IBEX supplies addresses as they are, the [Wishbone spec][1] mandates that ADR_O be addressed in units of data port size, the lower bits being determined by SEL_O.  A similar misrepresentation is present in Renode cosimulation integration, these fixes need to go in tandem.

Upstream PR: https://github.com/renode/renode/pull/727

The upstream change is intended to be used by CoreBlocks Open Source RISC-V CPU for integration with Renode. Currently it would need to be worked around by using extra conversion, like the suggested one here, but inverted.

Context: https://github.com/kuznia-rdzeni/coreblocks/pull/778

[1]: https://wishbone-interconnect.readthedocs.io/en/latest/02_interface.html#master-signals
